### PR TITLE
Add Transport module stubs

### DIFF
--- a/pkg/abstraction/transport.go
+++ b/pkg/abstraction/transport.go
@@ -3,9 +3,6 @@ package abstraction
 // TransportEvent is an event of the Transport module
 type TransportEvent string
 
-// TransportTarget specifies who should get certain information
-type TransportTarget uint16
-
 // TransportNotification is a notification of an event being received
 type TransportNotification interface {
 	Event() TransportEvent

--- a/pkg/transport/errors.go
+++ b/pkg/transport/errors.go
@@ -1,0 +1,15 @@
+package transport
+
+import (
+	"fmt"
+
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+)
+
+type ErrUnrecognizedEvent struct {
+	event abstraction.TransportEvent
+}
+
+func (err ErrUnrecognizedEvent) Error() string {
+	return fmt.Sprintf("unrecognized event %s", err.event)
+}

--- a/pkg/transport/errors.go
+++ b/pkg/transport/errors.go
@@ -6,6 +6,8 @@ import (
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
 )
 
+// ErrUnrecognizedEvent is returned when the event passed to transport
+// has an invalid type or it is not recognized.
 type ErrUnrecognizedEvent struct {
 	event abstraction.TransportEvent
 }

--- a/pkg/transport/messages.go
+++ b/pkg/transport/messages.go
@@ -43,14 +43,12 @@ func (message PacketMessage) Id() abstraction.PacketId {
 
 // FileWriteMessage request a file to be written to a specific target
 type FileWriteMessage struct {
-	data   io.Reader
-	target abstraction.TransportTarget
+	data io.Reader
 }
 
-func NewFileWriteMessage(data io.Reader, target abstraction.TransportTarget) FileWriteMessage {
+func NewFileWriteMessage(data io.Reader) FileWriteMessage {
 	return FileWriteMessage{
-		data:   data,
-		target: target,
+		data: data,
 	}
 }
 
@@ -69,17 +67,12 @@ func (message FileWriteMessage) Read(p []byte) (n int, err error) {
 	return message.data.Read(p)
 }
 
-func (message FileWriteMessage) Target() abstraction.TransportTarget {
-	return message.target
-}
-
 // FileReadMessage request a file to be read from the specific target.
 type FileReadMessage struct {
 	output io.Writer
-	target abstraction.TransportTarget
 }
 
-func NewFileReadMessage(output io.Writer, target abstraction.Transport) FileReadMessage {
+func NewFileReadMessage(output io.Writer) FileReadMessage {
 	return FileReadMessage{
 		output: output,
 	}
@@ -98,8 +91,4 @@ func (message FileReadMessage) Output() io.Writer {
 // Write maps the message output write method
 func (message FileReadMessage) Write(p []byte) (n int, err error) {
 	return message.output.Write(p)
-}
-
-func (message FileReadMessage) Target() abstraction.TransportTarget {
-	return message.target
 }

--- a/pkg/transport/messages.go
+++ b/pkg/transport/messages.go
@@ -7,9 +7,12 @@ import (
 )
 
 const (
-	PacketEvent    abstraction.TransportEvent = "packet"
+	// PacketEvent is triggered when a packet is sent or received
+	PacketEvent abstraction.TransportEvent = "packet"
+	// FileWriteEvent is used to request a file write through tftp
 	FileWriteEvent abstraction.TransportEvent = "file-push"
-	FileReadEvent  abstraction.TransportEvent = "file-pull"
+	// FileReadEvent is used to request a file read through tftp
+	FileReadEvent abstraction.TransportEvent = "file-pull"
 )
 
 // PacketMessage request a packet to be sent to the vehicle.
@@ -23,14 +26,17 @@ func NewPacketMessage(packet abstraction.Packet) PacketMessage {
 	}
 }
 
+// Event always returns PacketEvent
 func (message PacketMessage) Event() abstraction.TransportEvent {
 	return PacketEvent
 }
 
+// Packet returns the packet associated with the message
 func (message PacketMessage) Packet() abstraction.Packet {
 	return message.packet
 }
 
+// Id returns the Id of the packet associated with the message
 func (message PacketMessage) Id() abstraction.PacketId {
 	return message.packet.Id()
 }
@@ -48,14 +54,17 @@ func NewFileWriteMessage(data io.Reader, target abstraction.TransportTarget) Fil
 	}
 }
 
+// Event is always FileWriteEvent
 func (message FileWriteMessage) Event() abstraction.TransportEvent {
 	return FileWriteEvent
 }
 
+// Data returns the data to be written through tftp
 func (message FileWriteMessage) Data() io.Reader {
 	return message.data
 }
 
+// Read maps the message data read method so it can be used directly
 func (message FileWriteMessage) Read(p []byte) (n int, err error) {
 	return message.data.Read(p)
 }
@@ -76,14 +85,17 @@ func NewFileReadMessage(output io.Writer, target abstraction.Transport) FileRead
 	}
 }
 
+// Event always returns FileReadEvent
 func (message FileReadMessage) Event() abstraction.TransportEvent {
 	return FileReadEvent
 }
 
+// Output returns where data read should be written
 func (message FileReadMessage) Output() io.Writer {
 	return message.output
 }
 
+// Write maps the message output write method
 func (message FileReadMessage) Write(p []byte) (n int, err error) {
 	return message.output.Write(p)
 }

--- a/pkg/transport/messages.go
+++ b/pkg/transport/messages.go
@@ -6,6 +6,12 @@ import (
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
 )
 
+const (
+	PacketEvent    abstraction.TransportEvent = "packet"
+	FileWriteEvent abstraction.TransportEvent = "file-push"
+	FileReadEvent  abstraction.TransportEvent = "file-pull"
+)
+
 // PacketMessage request a packet to be sent to the vehicle.
 type PacketMessage struct {
 	packet abstraction.Packet
@@ -18,7 +24,7 @@ func NewPacketMessage(packet abstraction.Packet) PacketMessage {
 }
 
 func (message PacketMessage) Event() abstraction.TransportEvent {
-	return "packet"
+	return PacketEvent
 }
 
 func (message PacketMessage) Packet() abstraction.Packet {
@@ -43,7 +49,7 @@ func NewFileWriteMessage(data io.Reader, target abstraction.TransportTarget) Fil
 }
 
 func (message FileWriteMessage) Event() abstraction.TransportEvent {
-	return "file-response"
+	return FileWriteEvent
 }
 
 func (message FileWriteMessage) Data() io.Reader {
@@ -71,7 +77,7 @@ func NewFileReadMessage(output io.Writer, target abstraction.Transport) FileRead
 }
 
 func (message FileReadMessage) Event() abstraction.TransportEvent {
-	return "file-request"
+	return FileReadEvent
 }
 
 func (message FileReadMessage) Output() io.Writer {

--- a/pkg/transport/network/sniffer.go
+++ b/pkg/transport/network/sniffer.go
@@ -1,0 +1,3 @@
+package network
+
+type Sniffer struct{}

--- a/pkg/transport/network/sniffer.go
+++ b/pkg/transport/network/sniffer.go
@@ -1,3 +1,10 @@
 package network
 
+type Socket struct {
+	LocalIP    string
+	LocalPort  uint16
+	RemoteIP   string
+	RemotePort uint16
+}
+
 type Sniffer struct{}

--- a/pkg/transport/network/tcp.go
+++ b/pkg/transport/network/tcp.go
@@ -1,0 +1,3 @@
+package network
+
+type TCPConn struct{}

--- a/pkg/transport/network/tftp.go
+++ b/pkg/transport/network/tftp.go
@@ -1,0 +1,3 @@
+package network
+
+type TFTPConn struct{}

--- a/pkg/transport/notifications.go
+++ b/pkg/transport/notifications.go
@@ -13,7 +13,7 @@ func NewPacketNotification(packet abstraction.Packet) PacketNotification {
 }
 
 func (notification PacketNotification) Event() abstraction.TransportEvent {
-	return "packet"
+	return PacketEvent
 }
 
 func (notification PacketNotification) Packet() abstraction.Packet {

--- a/pkg/transport/notifications.go
+++ b/pkg/transport/notifications.go
@@ -2,6 +2,7 @@ package transport
 
 import "github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
 
+// PacketNofitication notifies of an incoming message
 type PacketNotification struct {
 	packet abstraction.Packet
 }
@@ -12,14 +13,17 @@ func NewPacketNotification(packet abstraction.Packet) PacketNotification {
 	}
 }
 
+// Event always returns PacketEvent
 func (notification PacketNotification) Event() abstraction.TransportEvent {
 	return PacketEvent
 }
 
+// Packet returns the packet associated with the message
 func (notification PacketNotification) Packet() abstraction.Packet {
 	return notification.packet
 }
 
+// Id returns the id of the packet associated with the message
 func (notification PacketNotification) Id() abstraction.PacketId {
 	return notification.packet.Id()
 }

--- a/pkg/transport/presentation/decoder.go
+++ b/pkg/transport/presentation/decoder.go
@@ -1,0 +1,3 @@
+package presentation
+
+type PacketDecoder struct{}

--- a/pkg/transport/presentation/encoder.go
+++ b/pkg/transport/presentation/encoder.go
@@ -1,0 +1,3 @@
+package presentation
+
+type PacketEncoder struct{}

--- a/pkg/transport/session/socket.go
+++ b/pkg/transport/session/socket.go
@@ -1,0 +1,3 @@
+package session
+
+type SocketBuffer struct{}

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -1,0 +1,15 @@
+package transport
+
+import "github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+
+type Transport struct {
+	api abstraction.TransportAPI
+}
+
+func (transport *Transport) SendMessage(message abstraction.TransportMessage) error {
+	panic("TODO!")
+}
+
+func (transport *Transport) SetAPI(api abstraction.TransportAPI) {
+	transport.api = api
+}

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -7,6 +7,12 @@ import (
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/session"
 )
 
+// Transport is the module in charge of handling network communication with
+// the vehicle.
+//
+// It uses events to differentiate different kinds of messages. Each message
+// or notification has an associated event which is used to determine the
+// action to take.
 type Transport struct {
 	decoder *presentation.PacketDecoder
 	encoder *presentation.PacketEncoder
@@ -21,6 +27,8 @@ type Transport struct {
 	api abstraction.TransportAPI
 }
 
+// SendMessage triggers an event to send something to the vehicle. Some messages
+// might additional means to pass information around (e.g. file read and write)
 func (transport *Transport) SendMessage(message abstraction.TransportMessage) error {
 	switch msg := message.(type) {
 	case PacketMessage:
@@ -46,6 +54,7 @@ func (transport *Transport) handleFileRead(message FileReadMessage) error {
 	panic("TODO!")
 }
 
+// SetAPI sets the API that the Transport will use
 func (transport *Transport) SetAPI(api abstraction.TransportAPI) {
 	transport.api = api
 	// TODO: make decoder use the api Notify method

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -22,9 +22,31 @@ type Transport struct {
 }
 
 func (transport *Transport) SendMessage(message abstraction.TransportMessage) error {
+	switch msg := message.(type) {
+	case PacketMessage:
+		return transport.handlePacketEvent(msg)
+	case FileWriteMessage:
+		return transport.handleFileWrite(msg)
+	case FileReadMessage:
+		return transport.handleFileRead(msg)
+	default:
+		return ErrUnrecognizedEvent{message.Event()}
+	}
+}
+
+func (transport *Transport) handlePacketEvent(message PacketMessage) error {
+	panic("TODO!")
+}
+
+func (transport *Transport) handleFileWrite(message FileWriteMessage) error {
+	panic("TODO!")
+}
+
+func (transport *Transport) handleFileRead(message FileReadMessage) error {
 	panic("TODO!")
 }
 
 func (transport *Transport) SetAPI(api abstraction.TransportAPI) {
 	transport.api = api
+	// TODO: make decoder use the api Notify method
 }

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -1,8 +1,23 @@
 package transport
 
-import "github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+import (
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/network"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/presentation"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/session"
+)
 
 type Transport struct {
+	decoder *presentation.PacketDecoder
+	encoder *presentation.PacketEncoder
+
+	conversations map[network.Socket]*session.SocketBuffer
+
+	sniffer *network.Sniffer
+	boards  map[abstraction.BoardId]*network.TCPConn
+
+	tftp *network.TFTPConn
+
 	api abstraction.TransportAPI
 }
 


### PR DESCRIPTION
A *stub* is a placeholder for future code.

This PR adds a stub for the transport module and all its immediate dependencies.

The Transport module is in charge of network communication. It has three associated layers of the OSI model: transport, session and presentation.

The transport layer (packet called `network`, since `transport` is already taken by the module) handles TCP and UDP communication. It captures all the traffic and establishes the connections with the boards using TCP and TFTP connections.

The session layer (packet `session`) handles all the incoming traffic through the sniffer so that it is received in a structured way at the decoder. It splits the different conversations so it is easier to use later.

The presentation layer (packet `presentation`) is in charge of decoding and encoding all data. This is to turn binary data read from the wire to specific structs and turning specific structs to binary data so it is written.