### PR TITLE
Implement TCP connections

### DIFF
--- a/pkg/abstraction/transport.go
+++ b/pkg/abstraction/transport.go
@@ -1,5 +1,9 @@
 package abstraction
 
+// TransportTarget uniquely identifies a target resource for the Transport
+// module operations
+type TransportTarget string
+
 // TransportEvent is an event of the Transport module
 type TransportEvent string
 

--- a/pkg/transport/network/tcp.go
+++ b/pkg/transport/network/tcp.go
@@ -1,3 +1,0 @@
-package network
-
-type TCPConn struct{}

--- a/pkg/transport/network/tcp/client.go
+++ b/pkg/transport/network/tcp/client.go
@@ -1,0 +1,9 @@
+package tcp
+
+type TCPClient struct {
+	onConnection func(*TCPConn)
+}
+
+func (client *TCPClient) SetOnConnection(callback func(*TCPConn)) {
+	client.onConnection = callback
+}

--- a/pkg/transport/network/tcp/client.go
+++ b/pkg/transport/network/tcp/client.go
@@ -37,6 +37,9 @@ func (b *backoff) increase() {
 	}
 }
 
+// Assertion to check the TCPClient is a TCPSource
+var _ TCPSource = &TCPClient{}
+
 type TCPClient struct {
 	target       abstraction.TransportTarget
 	raddr        net.Addr

--- a/pkg/transport/network/tcp/client.go
+++ b/pkg/transport/network/tcp/client.go
@@ -1,9 +1,117 @@
 package tcp
 
-type TCPClient struct {
-	onConnection func(*TCPConn)
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/network"
+)
+
+var (
+	CLIENT_INITIAL_BACKOFF = time.Millisecond * 100
+	CLIENT_MAX_BACKOFF     = time.Second * 5
+)
+
+type backoff struct {
+	base    time.Duration
+	current time.Duration
+	rate    float32
+	max     time.Duration
 }
 
-func (client *TCPClient) SetOnConnection(callback func(*TCPConn)) {
+func (b *backoff) next() <-chan time.Time {
+	timer := time.NewTimer(b.current)
+	return timer.C
+}
+
+func (b *backoff) reset() {
+	b.current = b.base
+}
+
+func (b *backoff) increase() {
+	b.current = time.Duration(float32(b.current) * b.rate)
+	if b.current > b.max {
+		b.current = b.max
+	}
+}
+
+type TCPClient struct {
+	target       abstraction.TransportTarget
+	raddr        net.Addr
+	dialer       net.Dialer
+	onConnection connectionCallback
+	onError      errorCallback
+	retry        backoff
+}
+
+func NewClient(target abstraction.TransportTarget, socket network.Socket) (*TCPClient, error) {
+	laddr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", socket.SrcIP, socket.SrcPort))
+	if err != nil {
+		return nil, err
+	}
+	raddr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", socket.DstIP, socket.DstPort))
+	if err != nil {
+		return nil, err
+	}
+
+	return &TCPClient{
+		target: target,
+		raddr:  raddr,
+		dialer: net.Dialer{
+			LocalAddr: laddr,
+			KeepAlive: -1, // Disable default keepalive (defaults to 15s)
+			Timeout:   0,  // Default value -> No timeout
+		},
+		retry: backoff{
+			base:    CLIENT_INITIAL_BACKOFF,
+			current: CLIENT_INITIAL_BACKOFF,
+			rate:    2,
+			max:     CLIENT_MAX_BACKOFF,
+		},
+	}, nil
+}
+
+func (client *TCPClient) SetTimeout(timeout *time.Duration) {
+	if timeout != nil {
+		client.dialer.Timeout = *timeout
+	} else {
+		client.dialer.Timeout = 0
+	}
+}
+
+func (client *TCPClient) SetKeepalive(keepalive *time.Duration) {
+	if keepalive != nil {
+		client.dialer.KeepAlive = *keepalive
+	} else {
+		client.dialer.KeepAlive = -1
+	}
+}
+
+func (client *TCPClient) SetOnConnection(callback connectionCallback) {
 	client.onConnection = callback
+}
+
+func (client *TCPClient) SetOnError(callback errorCallback) {
+	client.onError = callback
+}
+
+func (client *TCPClient) Run(cancel <-chan struct{}) {
+	client.retry.reset()
+	for {
+		backoffTimer := client.retry.next()
+		select {
+		case <-backoffTimer:
+			conn, err := client.dialer.Dial("tcp", client.raddr.String())
+			if err == nil {
+				client.onConnection(client.target, conn.(*net.TCPConn))
+				return
+			}
+			client.onError(client.target, err)
+			client.retry.increase()
+		case <-cancel:
+			return
+		}
+	}
 }

--- a/pkg/transport/network/tcp/client.go
+++ b/pkg/transport/network/tcp/client.go
@@ -10,10 +10,13 @@ import (
 )
 
 var (
+	// CLIENT_INITIAL_BACKOFF is the starting value for the client backoff
 	CLIENT_INITIAL_BACKOFF = time.Millisecond * 100
-	CLIENT_MAX_BACKOFF     = time.Second * 5
+	// CLIENT_MAX_BACKOFF is the max value for the client backoff
+	CLIENT_MAX_BACKOFF = time.Second * 5
 )
 
+// backoff is an abstraction over an exponential backoff algorithmn
 type backoff struct {
 	base    time.Duration
 	current time.Duration
@@ -21,15 +24,19 @@ type backoff struct {
 	max     time.Duration
 }
 
+// next returns a channel where a message will be sent once the next period
+// of time elapses.
 func (b *backoff) next() <-chan time.Time {
 	timer := time.NewTimer(b.current)
 	return timer.C
 }
 
+// reset resets the current value of the backoff to the default one
 func (b *backoff) reset() {
 	b.current = b.base
 }
 
+// increase sets the current value of the backoff to the next one
 func (b *backoff) increase() {
 	b.current = time.Duration(float32(b.current) * b.rate)
 	if b.current > b.max {
@@ -40,6 +47,10 @@ func (b *backoff) increase() {
 // Assertion to check the TCPClient is a TCPSource
 var _ TCPSource = &TCPClient{}
 
+// TCPClient is a TCPSource that creates connections with a server.
+//
+// TCPClient must be used the same way as a regular TCPSource, extra methods provided
+// are just to configure certain aspects about it.
 type TCPClient struct {
 	target       abstraction.TransportTarget
 	raddr        net.Addr
@@ -49,6 +60,12 @@ type TCPClient struct {
 	retry        backoff
 }
 
+// NewClient creates a new TCPClient for the specified socket.
+//
+// It returns a non nil err if the one of the socket addresses are invalid.
+//
+// Target is used internally by the TransportModule to identify the client, it should follow
+// this form: "client/<target>"
 func NewClient(target abstraction.TransportTarget, socket network.Socket) (*TCPClient, error) {
 	laddr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", socket.SrcIP, socket.SrcPort))
 	if err != nil {
@@ -76,30 +93,40 @@ func NewClient(target abstraction.TransportTarget, socket network.Socket) (*TCPC
 	}, nil
 }
 
-func (client *TCPClient) SetTimeout(timeout *time.Duration) {
-	if timeout != nil {
-		client.dialer.Timeout = *timeout
-	} else {
-		client.dialer.Timeout = 0
-	}
+// SetTimeout sets the timeout for the connection to happen, if the connection
+// isn't established before this time, it will generate an error and attempt to reconnect
+//
+// A timeout of 0 means no timeout
+func (client *TCPClient) SetTimeout(timeout time.Duration) {
+	client.dialer.Timeout = timeout
 }
 
-func (client *TCPClient) SetKeepalive(keepalive *time.Duration) {
-	if keepalive != nil {
-		client.dialer.KeepAlive = *keepalive
-	} else {
-		client.dialer.KeepAlive = -1
-	}
+// SetKeepalive sets the keepalive period for the connecion once it is established.
+//
+// A keepalive of 0 is a default keepalive (15s) and a negative keepalive disables it.
+func (client *TCPClient) SetKeepalive(keepalive time.Duration) {
+	client.dialer.KeepAlive = keepalive
 }
 
+// SetOnConnection registers the callback that will be used when a connection is made
 func (client *TCPClient) SetOnConnection(callback connectionCallback) {
 	client.onConnection = callback
 }
 
+// SetOnError registers the callback that will be used when an error making the connection occurs.
 func (client *TCPClient) SetOnError(callback errorCallback) {
 	client.onError = callback
 }
 
+// Run starts the connection of the client.
+//
+// If the connection fails, the client tries to reconnect using an exponential backoff algorithmn.
+//
+// Errors and connections are reported using the OnError and OnConnection callbacks, and should be
+// set before calling Run.
+//
+// Run will block, callers should run this as a goroutine. The execution can be halted by sending a
+// message to the cancel message.
 func (client *TCPClient) Run(cancel <-chan struct{}) {
 	client.retry.reset()
 	for {

--- a/pkg/transport/network/tcp/client.go
+++ b/pkg/transport/network/tcp/client.go
@@ -45,13 +45,13 @@ func (b *backoff) increase() {
 }
 
 // Assertion to check the TCPClient is a TCPSource
-var _ TCPSource = &TCPClient{}
+var _ Source = &Client{}
 
-// TCPClient is a TCPSource that creates connections with a server.
+// Client is a TCPSource that creates connections with a server.
 //
-// TCPClient must be used the same way as a regular TCPSource, extra methods provided
+// Client must be used the same way as a regular TCPSource, extra methods provided
 // are just to configure certain aspects about it.
-type TCPClient struct {
+type Client struct {
 	target       abstraction.TransportTarget
 	raddr        net.Addr
 	dialer       net.Dialer
@@ -66,7 +66,7 @@ type TCPClient struct {
 //
 // Target is used internally by the TransportModule to identify the client, it should follow
 // this form: "client/<target>"
-func NewClient(target abstraction.TransportTarget, socket network.Socket) (*TCPClient, error) {
+func NewClient(target abstraction.TransportTarget, socket network.Socket) (*Client, error) {
 	laddr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", socket.SrcIP, socket.SrcPort))
 	if err != nil {
 		return nil, err
@@ -76,7 +76,7 @@ func NewClient(target abstraction.TransportTarget, socket network.Socket) (*TCPC
 		return nil, err
 	}
 
-	return &TCPClient{
+	return &Client{
 		target: target,
 		raddr:  raddr,
 		dialer: net.Dialer{
@@ -97,24 +97,24 @@ func NewClient(target abstraction.TransportTarget, socket network.Socket) (*TCPC
 // isn't established before this time, it will generate an error and attempt to reconnect
 //
 // A timeout of 0 means no timeout
-func (client *TCPClient) SetTimeout(timeout time.Duration) {
+func (client *Client) SetTimeout(timeout time.Duration) {
 	client.dialer.Timeout = timeout
 }
 
 // SetKeepalive sets the keepalive period for the connecion once it is established.
 //
 // A keepalive of 0 is a default keepalive (15s) and a negative keepalive disables it.
-func (client *TCPClient) SetKeepalive(keepalive time.Duration) {
+func (client *Client) SetKeepalive(keepalive time.Duration) {
 	client.dialer.KeepAlive = keepalive
 }
 
 // SetOnConnection registers the callback that will be used when a connection is made
-func (client *TCPClient) SetOnConnection(callback connectionCallback) {
+func (client *Client) SetOnConnection(callback connectionCallback) {
 	client.onConnection = callback
 }
 
 // SetOnError registers the callback that will be used when an error making the connection occurs.
-func (client *TCPClient) SetOnError(callback errorCallback) {
+func (client *Client) SetOnError(callback errorCallback) {
 	client.onError = callback
 }
 
@@ -127,7 +127,7 @@ func (client *TCPClient) SetOnError(callback errorCallback) {
 //
 // Run will block, callers should run this as a goroutine. The execution can be halted by sending a
 // message to the cancel message.
-func (client *TCPClient) Run(cancel <-chan struct{}) {
+func (client *Client) Run(cancel <-chan struct{}) {
 	client.retry.reset()
 	for {
 		backoffTimer := client.retry.next()

--- a/pkg/transport/network/tcp/server.go
+++ b/pkg/transport/network/tcp/server.go
@@ -1,9 +1,18 @@
 package tcp
 
 type TCPServer struct {
-	onConnection func(*TCPConn)
+	onConnection connectionCallback
+	onError      errorCallback
 }
 
-func (server *TCPServer) SetOnConnection(callback func(*TCPConn)) {
+func (server *TCPServer) SetOnConnection(callback connectionCallback) {
 	server.onConnection = callback
+}
+
+func (server *TCPServer) SetOnError(callback errorCallback) {
+	server.onError = callback
+}
+
+func (server *TCPServer) Run() {
+
 }

--- a/pkg/transport/network/tcp/server.go
+++ b/pkg/transport/network/tcp/server.go
@@ -1,0 +1,9 @@
+package tcp
+
+type TCPServer struct {
+	onConnection func(*TCPConn)
+}
+
+func (server *TCPServer) SetOnConnection(callback func(*TCPConn)) {
+	server.onConnection = callback
+}

--- a/pkg/transport/network/tcp/server.go
+++ b/pkg/transport/network/tcp/server.go
@@ -11,6 +11,9 @@ type Address string
 
 type serverTargets = map[Address]abstraction.TransportTarget
 
+// Assertion to check the TCPServer is a TCPSource
+var _ TCPSource = &TCPServer{}
+
 type TCPServer struct {
 	name         abstraction.TransportTarget
 	targets      serverTargets

--- a/pkg/transport/network/tcp/server.go
+++ b/pkg/transport/network/tcp/server.go
@@ -14,12 +14,12 @@ type Address = string
 type serverTargets = map[Address]abstraction.TransportTarget
 
 // Assertion to check the TCPServer is a TCPSource
-var _ TCPSource = &TCPServer{}
+var _ Source = &Server{}
 
-// TCPServer is a TCPSource that gets connections from clients
+// Server is a TCPSource that gets connections from clients
 //
-// TCPServer must be used as any other TCPSource.
-type TCPServer struct {
+// Server must be used as any other TCPSource.
+type Server struct {
 	name         abstraction.TransportTarget
 	targets      serverTargets
 	listener     *net.TCPListener
@@ -30,7 +30,7 @@ type TCPServer struct {
 
 // NewServer creates a new TCPServer with the given name, local address and target connections.
 // It returns a non nil error if it fails to resolve the local address or when the listener creation fails.
-func NewServer(name abstraction.TransportTarget, laddr string, targets serverTargets) (*TCPServer, error) {
+func NewServer(name abstraction.TransportTarget, laddr string, targets serverTargets) (*Server, error) {
 	localAddr, err := net.ResolveTCPAddr("tcp", laddr)
 	if err != nil {
 		return nil, err
@@ -41,7 +41,7 @@ func NewServer(name abstraction.TransportTarget, laddr string, targets serverTar
 		return nil, err
 	}
 
-	return &TCPServer{
+	return &Server{
 		name:      name,
 		targets:   targets,
 		listener:  listener,
@@ -50,17 +50,17 @@ func NewServer(name abstraction.TransportTarget, laddr string, targets serverTar
 }
 
 // SetKeepalive sets the keepalive that will be applied to the connections established
-func (server *TCPServer) SetKeepalive(keepalive time.Duration) {
+func (server *Server) SetKeepalive(keepalive time.Duration) {
 	server.keepalive = keepalive
 }
 
 // SetOnConnection registers the callback that will be used when a connection is made
-func (server *TCPServer) SetOnConnection(callback connectionCallback) {
+func (server *Server) SetOnConnection(callback connectionCallback) {
 	server.onConnection = callback
 }
 
 // SetOnError registers the callback that will be used when an error making the connection occurs.
-func (server *TCPServer) SetOnError(callback errorCallback) {
+func (server *Server) SetOnError(callback errorCallback) {
 	server.onError = callback
 }
 
@@ -78,7 +78,7 @@ type acceptResult struct {
 // Callers should make sure the OnConnection and the OnError callbacks are provided before calling Run.
 //
 // The server execution can be stopped by sending a message to the cancel channel.
-func (server *TCPServer) Run(cancel <-chan struct{}) {
+func (server *Server) Run(cancel <-chan struct{}) {
 	defer server.listener.Close()
 	for {
 		acceptChan := make(chan acceptResult)
@@ -121,7 +121,7 @@ func (server *TCPServer) Run(cancel <-chan struct{}) {
 }
 
 // configureConn is a helper to apply all configuration to a connection.
-func (server *TCPServer) configureConn(conn *net.TCPConn) error {
+func (server *Server) configureConn(conn *net.TCPConn) error {
 	err := conn.SetKeepAlive(server.keepalive > 0)
 	if err != nil {
 		return err

--- a/pkg/transport/network/tcp/server.go
+++ b/pkg/transport/network/tcp/server.go
@@ -1,8 +1,39 @@
 package tcp
 
+import (
+	"net"
+
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+)
+
+type Address string
+
+type serverTargets = map[Address]abstraction.TransportTarget
+
 type TCPServer struct {
+	name         abstraction.TransportTarget
+	targets      serverTargets
+	listener     *net.TCPListener
 	onConnection connectionCallback
 	onError      errorCallback
+}
+
+func NewServer(name abstraction.TransportTarget, laddr string, targets serverTargets) (*TCPServer, error) {
+	localAddr, err := net.ResolveTCPAddr("tcp", laddr)
+	if err != nil {
+		return nil, err
+	}
+
+	listener, err := net.ListenTCP("tcp", localAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TCPServer{
+		name:     name,
+		targets:  targets,
+		listener: listener,
+	}, nil
 }
 
 func (server *TCPServer) SetOnConnection(callback connectionCallback) {
@@ -14,5 +45,20 @@ func (server *TCPServer) SetOnError(callback errorCallback) {
 }
 
 func (server *TCPServer) Run() {
+	for {
+		conn, err := server.listener.AcceptTCP()
+		if err != nil {
+			server.onError(server.name, err)
+		}
 
+		if target, ok := server.targets[Address(conn.RemoteAddr().String())]; ok {
+			server.onConnection(target, conn)
+		}
+
+		conn.Close()
+	}
+}
+
+func (server *TCPServer) Close() error {
+	return server.listener.Close()
 }

--- a/pkg/transport/network/tcp/tcp.go
+++ b/pkg/transport/network/tcp/tcp.go
@@ -8,39 +8,38 @@ import (
 
 type connectionCallback = func(abstraction.TransportTarget, *net.TCPConn)
 type errorCallback = func(abstraction.TransportTarget, error)
+type stateCallback = func(abstraction.TransportTarget, bool)
 
-type TCPSource interface {
+type Source interface {
 	Run(<-chan struct{})
 	SetOnConnection(connectionCallback)
 	SetOnError(errorCallback)
 }
 
-type TCPConn struct {
+type Conn struct {
 	target       abstraction.TransportTarget
 	conn         *net.TCPConn
 	onConnUpdate stateCallback
 }
 
-type stateCallback = func(abstraction.TransportTarget, bool)
-
-func NewConn(target abstraction.TransportTarget, conn *net.TCPConn, callback stateCallback) *TCPConn {
+func NewConn(target abstraction.TransportTarget, conn *net.TCPConn, callback stateCallback) *Conn {
 	callback(target, true)
-	return &TCPConn{
+	return &Conn{
 		target:       target,
 		conn:         conn,
 		onConnUpdate: callback,
 	}
 }
 
-func (tcp *TCPConn) Read(p []byte) (n int, err error) {
+func (tcp *Conn) Read(p []byte) (n int, err error) {
 	return tcp.conn.Read(p)
 }
 
-func (tcp *TCPConn) Write(p []byte) (n int, err error) {
+func (tcp *Conn) Write(p []byte) (n int, err error) {
 	return tcp.conn.Write(p)
 }
 
-func (tcp *TCPConn) Close() error {
+func (tcp *Conn) Close() error {
 	tcp.onConnUpdate(tcp.target, false)
 	return tcp.conn.Close()
 }

--- a/pkg/transport/network/tcp/tcp.go
+++ b/pkg/transport/network/tcp/tcp.go
@@ -1,0 +1,7 @@
+package tcp
+
+type TCPSource interface {
+	SetOnConnection(func(*TCPConn))
+}
+
+type TCPConn struct{}

--- a/pkg/transport/network/tcp/tcp.go
+++ b/pkg/transport/network/tcp/tcp.go
@@ -6,8 +6,13 @@ import (
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
 )
 
+type connectionCallback = func(abstraction.TransportTarget, *net.TCPConn)
+type errorCallback = func(abstraction.TransportTarget, error)
+
 type TCPSource interface {
-	SetOnConnection(func(*TCPConn))
+	Run()
+	SetOnConnection(connectionCallback)
+	SetOnError(errorCallback)
 }
 
 type TCPConn struct {

--- a/pkg/transport/network/tcp/tcp.go
+++ b/pkg/transport/network/tcp/tcp.go
@@ -1,7 +1,41 @@
 package tcp
 
+import (
+	"net"
+
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+)
+
 type TCPSource interface {
 	SetOnConnection(func(*TCPConn))
 }
 
-type TCPConn struct{}
+type TCPConn struct {
+	target       abstraction.TransportTarget
+	conn         *net.TCPConn
+	onConnUpdate stateCallback
+}
+
+type stateCallback = func(abstraction.TransportTarget, bool)
+
+func NewConn(target abstraction.TransportTarget, conn *net.TCPConn, callback stateCallback) *TCPConn {
+	callback(target, true)
+	return &TCPConn{
+		target:       target,
+		conn:         conn,
+		onConnUpdate: callback,
+	}
+}
+
+func (tcp *TCPConn) Read(p []byte) (n int, err error) {
+	return tcp.conn.Read(p)
+}
+
+func (tcp *TCPConn) Write(p []byte) (n int, err error) {
+	return tcp.conn.Write(p)
+}
+
+func (tcp *TCPConn) Close() error {
+	tcp.onConnUpdate(tcp.target, false)
+	return tcp.conn.Close()
+}

--- a/pkg/transport/network/tcp/tcp.go
+++ b/pkg/transport/network/tcp/tcp.go
@@ -10,7 +10,7 @@ type connectionCallback = func(abstraction.TransportTarget, *net.TCPConn)
 type errorCallback = func(abstraction.TransportTarget, error)
 
 type TCPSource interface {
-	Run()
+	Run(<-chan struct{})
 	SetOnConnection(connectionCallback)
 	SetOnError(errorCallback)
 }

--- a/pkg/transport/network/tcp/tcp.go
+++ b/pkg/transport/network/tcp/tcp.go
@@ -6,22 +6,55 @@ import (
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
 )
 
+// These callbacks are used by the Source and the Conn structs
+// connectionCallback is called when a source has obtained a new connection
 type connectionCallback = func(abstraction.TransportTarget, *net.TCPConn)
+
+// errorCallback is called when a source encounters an error creating a connection
 type errorCallback = func(abstraction.TransportTarget, error)
+
+// stateCallback is called when a Conn connection state changes
 type stateCallback = func(abstraction.TransportTarget, bool)
 
+// Source is an interface for different ways of creating TCP connections.
+//
+// When using sources the caller should first use SetOnConnection and SetOnError
+// to ensure both that connections are created correctly and any errors are handled.
+//
+// Once the callbacks are set, the consumer should execute Run in a goroutine, passing
+// an optional channel to stop the execution of the Source
 type Source interface {
+	// Run starts sourcing connections. Implementations might block, so it is advised
+	// to call this in a goroutine to prevent blocking.
+	//
+	// The provided channel is used to stop the runner, when a message is sent the
+	// Source stops creating connections.
 	Run(<-chan struct{})
+
+	// SetOnConnection gives the Source the callback it should call when a new connection
+	// is established.
 	SetOnConnection(connectionCallback)
+
+	// SetOnError gives the Source the callback it should call when an error making a
+	// connection is encountered.
 	SetOnError(errorCallback)
 }
 
+// Conn is a wrapper around a net.TCPConn which gives it an associated target and
+// other callbacks
 type Conn struct {
 	target       abstraction.TransportTarget
 	conn         *net.TCPConn
 	onConnUpdate stateCallback
 }
 
+// NewConn creates a new Conn with the provided parameters
+//
+// target is the TransportTarget associated with this Conn
+//
+// conn is the actual network connection
+//
+// callback is the callback that will be called when the conn connects / disconnects
 func NewConn(target abstraction.TransportTarget, conn *net.TCPConn, callback stateCallback) *Conn {
 	callback(target, true)
 	return &Conn{
@@ -31,14 +64,23 @@ func NewConn(target abstraction.TransportTarget, conn *net.TCPConn, callback sta
 	}
 }
 
+// Target returns the connection TransportTarget
+func (tcp *Conn) Target() abstraction.TransportTarget {
+	return tcp.target
+}
+
+// Read maps the underlying conn Read method
 func (tcp *Conn) Read(p []byte) (n int, err error) {
 	return tcp.conn.Read(p)
 }
 
+// Write maps the underlying conn Write method
 func (tcp *Conn) Write(p []byte) (n int, err error) {
 	return tcp.conn.Write(p)
 }
 
+// Close maps the unterlying conn Close method, calling the appropiate callbacks
+// in the process.
 func (tcp *Conn) Close() error {
 	tcp.onConnUpdate(tcp.target, false)
 	return tcp.conn.Close()

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -4,6 +4,7 @@ import (
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/network"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/network/sniffer"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/network/tcp"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/presentation"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/session"
 )
@@ -21,7 +22,7 @@ type Transport struct {
 	conversations map[network.Socket]*session.SocketBuffer
 
 	sniffer *sniffer.Sniffer
-	boards  map[abstraction.BoardId]*network.TCPConn
+	boards  map[abstraction.BoardId]*tcp.Conn
 
 	tftp *network.TFTPConn
 


### PR DESCRIPTION
Implement the TCP logic. There are two main parts to it: the `TCPSource` and the `TCPConn`.

`TCPSource` exists because for each board we can either establish a connection as a server or as a client. The struct `TCPClient` is a `TCPSource` for single direct connections and the struct `TCPServer` for multiple connections. This allows to abstract the "establishing connection" from the "using connection logic". Sources run and notify when a connection is made through callbacks.

`TCPClient` retries to reconnect if the connection fails using an exponential backoff. Once the connection is created, `TCPConn` is in charge of notifying disconnections and external logic should handle calling again `TCPClient.Run()`

`TCPServer` creates a TCP listener and accepts connections specified on a list.

`TCPConn` allows to read and write from the connection, it also provides a callback to notify when the connection status changes (sends `true` when connected and `false` when disconnected).