### PR TITLE
TFTP Client

### DIFF
--- a/pkg/transport/network/tftp.go
+++ b/pkg/transport/network/tftp.go
@@ -1,3 +1,0 @@
-package network
-
-type TFTPConn struct{}

--- a/pkg/transport/network/tftp/client.go
+++ b/pkg/transport/network/tftp/client.go
@@ -1,0 +1,14 @@
+package tftp
+
+import "io"
+
+type Client struct {
+}
+
+func (client *Client) Read(filename string, output io.Writer) error {
+	panic("TODO!")
+}
+
+func (client *Client) Write(filename string, input io.Reader) error {
+	panic("TODO!")
+}

--- a/pkg/transport/network/tftp/client.go
+++ b/pkg/transport/network/tftp/client.go
@@ -1,14 +1,39 @@
 package tftp
 
-import "io"
+import (
+	"io"
+
+	"github.com/pin/tftp/v3"
+)
 
 type Client struct {
+	mode       string
+	conn       *tftp.Client
+	onProgress progressCallback
 }
 
-func (client *Client) Read(filename string, output io.Writer) error {
-	panic("TODO!")
+func (client *Client) ReadFile(filename string, output io.Writer) (int64, error) {
+	recv, err := client.conn.Receive(filename, client.mode)
+	if err != nil {
+		return 0, err
+	}
+
+	writer := newProgressWriter(filename, client.onProgress, output)
+
+	n, err := recv.WriteTo(writer)
+
+	return n, err
 }
 
-func (client *Client) Write(filename string, input io.Reader) error {
-	panic("TODO!")
+func (client *Client) WriteFile(filename string, input io.Reader) (int64, error) {
+	send, err := client.conn.Send(filename, client.mode)
+	if err != nil {
+		return 0, err
+	}
+
+	reader := newProgressReader(filename, client.onProgress, input)
+
+	n, err := send.ReadFrom(reader)
+
+	return n, err
 }

--- a/pkg/transport/network/tftp/client.go
+++ b/pkg/transport/network/tftp/client.go
@@ -6,18 +6,26 @@ import (
 	"github.com/pin/tftp/v3"
 )
 
+// transferMode is the mode for tftp data transfer, this can be either netascii or binary
 type transferMode string
 
 const (
+	// transfer information in binary mode
 	BinaryMode transferMode = "binary"
-	AsciiMode  transferMode = "netascii"
+	// transfer information as text
+	AsciiMode transferMode = "netascii"
 )
 
+// Client creates a connection with a TFTP server, it handles file uploads and downloads,
+// providing a callback to notify of progress
 type Client struct {
 	conn       *tftp.Client
 	onProgress progressCallback
 }
 
+// NewClient creates a new client with the provided options.
+//
+// addr is the server addres where the client will connect to
 func NewClient(addr string, opts ...clientOption) (*Client, error) {
 	conn, err := tftp.NewClient(addr)
 	if err != nil {
@@ -38,6 +46,8 @@ func NewClient(addr string, opts ...clientOption) (*Client, error) {
 	return client, nil
 }
 
+// ReadFile reads the file specified with filename from the server.
+// The file is written to the output Writer.
 func (client *Client) ReadFile(filename string, mode transferMode, output io.Writer) (int64, error) {
 	recv, err := client.conn.Receive(filename, string(mode))
 	if err != nil {
@@ -51,6 +61,8 @@ func (client *Client) ReadFile(filename string, mode transferMode, output io.Wri
 	return n, err
 }
 
+// WriteFile writes the file specified with the filename to the server.
+// The file is read from the input Reader.
 func (client *Client) WriteFile(filename string, mode transferMode, input io.Reader) (int64, error) {
 	send, err := client.conn.Send(filename, string(mode))
 	if err != nil {

--- a/pkg/transport/network/tftp/options.go
+++ b/pkg/transport/network/tftp/options.go
@@ -2,8 +2,11 @@ package tftp
 
 import "time"
 
+// clientOption is an option that can be applied to a Client.
+// It might fail and return the reason.
 type clientOption func(client *Client) error
 
+// WithProgressCallback will set the progress callback for the client.
 func WithProgressCallback(callback progressCallback) clientOption {
 	return func(client *Client) error {
 		client.onProgress = callback
@@ -11,6 +14,7 @@ func WithProgressCallback(callback progressCallback) clientOption {
 	}
 }
 
+// WithBackoff will specify the backoff algorithm for the client.
 func WithBackoff(backoff func(int) time.Duration) clientOption {
 	return func(client *Client) error {
 		client.conn.SetBackoff(backoff)
@@ -18,6 +22,7 @@ func WithBackoff(backoff func(int) time.Duration) clientOption {
 	}
 }
 
+// WithBlockSize will specify the block size for messages exchanged.
 func WithBlockSize(size int) clientOption {
 	return func(client *Client) error {
 		client.conn.SetBlockSize(size)
@@ -25,6 +30,7 @@ func WithBlockSize(size int) clientOption {
 	}
 }
 
+// WithRetries will set the max retries before aborting the transfer.
 func WithRetries(count int) clientOption {
 	return func(client *Client) error {
 		client.conn.SetRetries(count)
@@ -32,6 +38,7 @@ func WithRetries(count int) clientOption {
 	}
 }
 
+// WithTimeout will set the time between retries the client has.
 func WithTimeout(timeout time.Duration) clientOption {
 	return func(client *Client) error {
 		client.conn.SetTimeout(timeout)

--- a/pkg/transport/network/tftp/options.go
+++ b/pkg/transport/network/tftp/options.go
@@ -1,0 +1,40 @@
+package tftp
+
+import "time"
+
+type clientOption func(client *Client) error
+
+func WithProgressCallback(callback progressCallback) clientOption {
+	return func(client *Client) error {
+		client.onProgress = callback
+		return nil
+	}
+}
+
+func WithBackoff(backoff func(int) time.Duration) clientOption {
+	return func(client *Client) error {
+		client.conn.SetBackoff(backoff)
+		return nil
+	}
+}
+
+func WithBlockSize(size int) clientOption {
+	return func(client *Client) error {
+		client.conn.SetBlockSize(size)
+		return nil
+	}
+}
+
+func WithRetries(count int) clientOption {
+	return func(client *Client) error {
+		client.conn.SetRetries(count)
+		return nil
+	}
+}
+
+func WithTimeout(timeout time.Duration) clientOption {
+	return func(client *Client) error {
+		client.conn.SetTimeout(timeout)
+		return nil
+	}
+}

--- a/pkg/transport/network/tftp/progress.go
+++ b/pkg/transport/network/tftp/progress.go
@@ -2,18 +2,22 @@ package tftp
 
 import "io"
 
+// progressCallback is a function called when progress reading or writing a file is made
 type progressCallback = func(file string, amount int)
 
+// fileProgress holds information on the file and callback assigned to it
 type fileProgress struct {
 	file     string
 	callback progressCallback
 }
 
+// progressReader holds all the information to notify of progress when reading a file
 type progressReader struct {
 	fileProgress
 	reader io.Reader
 }
 
+// newProgressReader creates a new progressReader with the provided parameters
 func newProgressReader(file string, callback progressCallback, reader io.Reader) progressReader {
 	return progressReader{
 		fileProgress: fileProgress{
@@ -24,17 +28,20 @@ func newProgressReader(file string, callback progressCallback, reader io.Reader)
 	}
 }
 
+// Read maps the unerlying reader Read method and calls the progress callback after reading
 func (progress progressReader) Read(p []byte) (n int, err error) {
 	n, err = progress.reader.Read(p)
 	progress.callback(progress.file, n)
 	return
 }
 
+// progressWriter holds all the information to notify of progress when writing a file
 type progressWriter struct {
 	fileProgress
 	writer io.Writer
 }
 
+// newProgressWriter creates a new progressWriter with the provided parameters
 func newProgressWriter(file string, callback progressCallback, writer io.Writer) progressWriter {
 	return progressWriter{
 		fileProgress: fileProgress{
@@ -45,6 +52,7 @@ func newProgressWriter(file string, callback progressCallback, writer io.Writer)
 	}
 }
 
+// Write maps the underlying writer Write method and calls the progress callback after writing
 func (progress progressWriter) Write(p []byte) (n int, err error) {
 	n, err = progress.writer.Write(p)
 	progress.callback(progress.file, n)

--- a/pkg/transport/network/tftp/progress.go
+++ b/pkg/transport/network/tftp/progress.go
@@ -1,0 +1,52 @@
+package tftp
+
+import "io"
+
+type progressCallback = func(file string, amount int)
+
+type fileProgress struct {
+	file     string
+	callback progressCallback
+}
+
+type progressReader struct {
+	fileProgress
+	reader io.Reader
+}
+
+func newProgressReader(file string, callback progressCallback, reader io.Reader) progressReader {
+	return progressReader{
+		fileProgress: fileProgress{
+			file:     file,
+			callback: callback,
+		},
+		reader: reader,
+	}
+}
+
+func (progress progressReader) Read(p []byte) (n int, err error) {
+	n, err = progress.reader.Read(p)
+	progress.callback(progress.file, n)
+	return
+}
+
+type progressWriter struct {
+	fileProgress
+	writer io.Writer
+}
+
+func newProgressWriter(file string, callback progressCallback, writer io.Writer) progressWriter {
+	return progressWriter{
+		fileProgress: fileProgress{
+			file:     file,
+			callback: callback,
+		},
+		writer: writer,
+	}
+}
+
+func (progress progressWriter) Write(p []byte) (n int, err error) {
+	n, err = progress.writer.Write(p)
+	progress.callback(progress.file, n)
+	return
+}

--- a/pkg/transport/network/tftp/progress.go
+++ b/pkg/transport/network/tftp/progress.go
@@ -31,7 +31,9 @@ func newProgressReader(file string, callback progressCallback, reader io.Reader)
 // Read maps the unerlying reader Read method and calls the progress callback after reading
 func (progress progressReader) Read(p []byte) (n int, err error) {
 	n, err = progress.reader.Read(p)
-	progress.callback(progress.file, n)
+	if progress.callback != nil {
+		progress.callback(progress.file, n)
+	}
 	return
 }
 
@@ -55,6 +57,8 @@ func newProgressWriter(file string, callback progressCallback, writer io.Writer)
 // Write maps the underlying writer Write method and calls the progress callback after writing
 func (progress progressWriter) Write(p []byte) (n int, err error) {
 	n, err = progress.writer.Write(p)
-	progress.callback(progress.file, n)
+	if progress.callback != nil {
+		progress.callback(progress.file, n)
+	}
 	return
 }

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -5,6 +5,7 @@ import (
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/network"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/network/sniffer"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/network/tcp"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/network/tftp"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/presentation"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/session"
 )
@@ -24,7 +25,7 @@ type Transport struct {
 	sniffer *sniffer.Sniffer
 	boards  map[abstraction.BoardId]*tcp.Conn
 
-	tftp *network.TFTPConn
+	tftp *tftp.Client
 
 	api abstraction.TransportAPI
 }


### PR DESCRIPTION
This PR adds the client implementation for TFTP. It mainly just maps the `pin/tftp` library to other methods to make it familiar to use and make it easy to get the download/upload progress.

The client can be configured with `clientOption`s. The implementation of these is best described with the code.

Setting a progress callback is optional and will be ignored if not set.